### PR TITLE
Document environment variables usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ A HDMI-CEC / IR to MQTT bridge written in Python 3 for connecting your AV-device
 * lirc + hardware to receive and send IR signals
 * python-lirc (https://pypi.python.org/pypi/python-lirc/)
 
+# Configuration
+
+You can either copy `config.default.ini` to `config.ini` and adjust its properties, or alternatively declare any of those as environment variables using the format `SECTION_KEY` (e.g., `MQTT_USER`).
+
 # Lirc
 
 You need a `lircrc` config file. This can be generated from the `lircd.conf` of your lirc daemon using the script `create_lircrc.py`.


### PR DESCRIPTION
~~In order to fully distance oneself from the obligation of using config files, we should allow most/all configuration properties to be defined using environment variables. Useful when using Docker on multiple devices!~~

Edit: In my haste I had not noticed that environment variables where already read in the following code block. I am therefore downgrading this PR to a simple documentation improvement.

https://github.com/michaelarnauts/cec-mqtt-bridge/blob/d6a4937d5f563f533c18b7c4aec884e15e989797/bridge.py#L224-L229

In my case, I am using [Resin.io](https://resin.io/) for orchestrating Docker/Balena deployments, which opens the possibility of having a single build deployed to multiple TV sets (well, to their respective RPis). All devices therefore share an identical code base and just rely on fleet-wide and device-specific environment variables. Yay, less micro-management! 😃