### PR TITLE
Added availability, mute, volume and volume/set topics 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The bridge publishes to the following topics:
 
 | topic                   | body                                    | remark                                           |
 |:------------------------|-----------------------------------------|--------------------------------------------------|
+| `prefix`/bridge/status  | `online` / `offline`                    | Report availability status of the bridge.        |
 | `prefix`/cec/`id`       | `on` / `off`                            | Report power status of device with id `id`.      |
 | `prefix`/cec/rx         | `command`                               | Notify that `command` was received.              |
 | `prefix`/ir/`remote`/rx | `key`                                   | Notify that `key` of `remote` was received. You have to configure `key` AND `remote` as config in the lircrc file.  |

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The bridge subscribes to the following topics:
 |:------------------------|-----------------------------------------|--------------------------------------------------|
 | `prefix`/cec/`id`/cmd   | `on` / `off`                            | Turn on/off device with id `id`.                 |
 | `prefix`/cec/cmd        | `mute` / `unmute` / `voldown` / `volup` | Sends the specified command to the audio system. |
+| `prefix`/cec/volume/set | `integer (0-100)`                       | Sets the volume level of the audio system to a specific level. |
 | `prefix`/cec/tx         | `commands`                              | Send the specified `commands` to the CEC bus. You can specify multiple commands by separating them with a space. Example: `cec/tx 15:44:41,15:45`. |
 | `prefix`/ir/`remote`/tx | `key`                                   | Send the specified `key` of `remote` to the IR transmitter. |
 
@@ -83,6 +84,8 @@ The bridge publishes to the following topics:
 |:------------------------|-----------------------------------------|--------------------------------------------------|
 | `prefix`/bridge/status  | `online` / `offline`                    | Report availability status of the bridge.        |
 | `prefix`/cec/`id`       | `on` / `off`                            | Report power status of device with id `id`.      |
+| `prefix`/cec/volume     | `integer (0-100)`                       | Report volume level of the audio system.         |
+| `prefix`/cec/mute       | `on` / `off`                            | Report mute status of the audio system.          |
 | `prefix`/cec/rx         | `command`                               | Notify that `command` was received.              |
 | `prefix`/ir/`remote`/rx | `key`                                   | Notify that `key` of `remote` was received. You have to configure `key` AND `remote` as config in the lircrc file.  |
 | `prefix`/ir/rx          | `key`                                   | Notify that `key` was received. You have to configure `key` in the lircrc file. This format is used if the remote is not given in the config file.  |

--- a/bridge.py
+++ b/bridge.py
@@ -127,12 +127,12 @@ def mqtt_on_message(client, userdata, message):
                                     cec_client.VolumeUp()
                                 else:
                                     cec_client.VolumeDown()
-                                attempts += 1
 
                             # Refresh the volume levels and wait for the value to return before each loop
                             cec_send('71', id=5)
                             time.sleep(.2)
                             volume = cec_volume()
+                            attempts += 1
                         return
 
                     raise Exception("Unknown command (%s)" % action)

--- a/bridge.py
+++ b/bridge.py
@@ -49,6 +49,9 @@ def mqtt_on_connect(client, userdata, flags, rc):
             (config['mqtt']['prefix'] + '/ir/+/tx', 0)
         ])
 
+    # Publish birth message
+    client.publish(config['mqtt']['prefix'] + '/bridge/status', 'online', qos=1, retain=True)
+
 
 def mqtt_on_message(client, userdata, message):
     """@type client: paho.mqtt.client """
@@ -206,6 +209,7 @@ def cec_refresh():
 
 def cleanup():
     mqtt_client.loop_stop()
+    mqtt_client.publish(config['mqtt']['prefix'] + '/bridge/status', 'offline', qos=1, retain=True)
     mqtt_client.disconnect()
     if int(config['ir']['enabled']) == 1:
         lirc.deinit()
@@ -276,6 +280,7 @@ try:
     mqtt_client.on_message = mqtt_on_message
     if config['mqtt']['user']:
         mqtt_client.username_pw_set(config['mqtt']['user'], password=config['mqtt']['password']);
+    mqtt_client.will_set(config['mqtt']['prefix'] + '/bridge/status', 'offline', qos=1, retain=True)
     mqtt_client.connect(config['mqtt']['broker'], int(config['mqtt']['port']), 60)
     mqtt_client.loop_start()
 

--- a/bridge.py
+++ b/bridge.py
@@ -40,6 +40,7 @@ def mqtt_on_connect(client, userdata, flags, rc):
         client.subscribe([
             (config['mqtt']['prefix'] + '/cec/cmd', 0),
             (config['mqtt']['prefix'] + '/cec/+/cmd', 0),
+            (config['mqtt']['prefix'] + '/cec/+/set', 0),
             (config['mqtt']['prefix'] + '/cec/tx', 0)
         ])
 
@@ -72,18 +73,22 @@ def mqtt_on_message(client, userdata, message):
 
                 if action == 'mute':
                     cec_client.AudioMute()
+                    cec_send('71', id=5)
                     return
 
                 if action == 'unmute':
                     cec_client.AudioUnmute()
+                    cec_send('71', id=5)
                     return
 
                 if action == 'voldown':
                     cec_client.VolumeDown()
+                    cec_send('71', id=5)
                     return
 
                 if action == 'volup':
                     cec_client.VolumeUp()
+                    cec_send('71', id=5)
                     return
 
                 raise Exception("Unknown command (%s)" % action)
@@ -94,6 +99,43 @@ def mqtt_on_message(client, userdata, message):
                     print(" Sending raw: %s" % command)
                     cec_send(command)
                 return
+
+            if split[2] == 'set':
+
+                if split[1] == 'volume':
+                    action = int(message.payload.decode())
+
+                    if action >= 0 and action <= 100:
+                        volume = cec_volume()
+
+                        # Attempt to set the correct volume, but try to avoid a never-ending loop due to rounding issues
+                        attempts = 0
+                        while volume != action and attempts <= 10:
+                            diff = abs(volume - action)
+
+                            # Run a bulk of vol up/down actions to close a large gap at first (inaccurate, but quick)
+                            if diff >= 10:
+                                for _ in range(round(diff / 2.5)):
+                                    if volume < action:
+                                        cec_client.VolumeUp()
+                                    else:
+                                        cec_client.VolumeDown()
+
+                            # Set the volume precisely after the bulk operations, try to avoid an endless loop due to rounding
+                            else:
+                                if volume < action:
+                                    cec_client.VolumeUp()
+                                else:
+                                    cec_client.VolumeDown()
+                                attempts += 1
+
+                            # Refresh the volume levels and wait for the value to return before each loop
+                            cec_send('71', id=5)
+                            time.sleep(.2)
+                            volume = cec_volume()
+                        return
+
+                    raise Exception("Unknown command (%s)" % action)
 
             if split[2] == 'cmd':
 
@@ -165,6 +207,34 @@ def cec_on_message(level, time, message):
             mqtt_send(config['mqtt']['prefix'] + '/cec/' + str(id), power, True)
             return
 
+        # Report Audio Status
+        m = re.search('>> ([0-9a-f])[0-9a-f]:7a:([0-9a-f]{2})', message)
+        if m:
+            volume = None
+            mute = None
+
+            audio_status = int(m.group(2), 16)
+            if audio_status <= 100:
+                volume = audio_status
+                mute = 'off'
+            elif audio_status >= 128:
+                volume = audio_status - 128
+                mute = 'on'
+
+            if isinstance(volume, int):
+                mqtt_send(config['mqtt']['prefix'] + '/cec/volume', volume, True)
+            if mute:
+                mqtt_send(config['mqtt']['prefix'] + '/cec/mute', mute, True)
+            return
+
+
+def cec_volume():
+    audio_status = cec_client.AudioStatus()
+    if audio_status <= 100:
+        return audio_status
+    elif audio_status >= 128:
+        return audio_status - 128
+
 
 def cec_send(cmd, id=None):
     if id is None:
@@ -202,6 +272,8 @@ def cec_refresh():
     try:
         for id in config['cec']['devices'].split(','):
             cec_send('8F', id=int(id))
+
+        cec_send('71', id=5)
 
     except Exception as e:
         print("Error during refreshing: ", str(e))


### PR DESCRIPTION
* `prefix/bridge/status` reports the bridge availability (from @renemarc )
* `prefix/cec/volume` reports the current volume level
* `prefix/cec/mute` reports the current mute status
* The bridge subscribes to `prefix/cec/volume/set` to set the volume to a specific level between 0 and 100

The code for setting the volume is a little wonky, but it works pretty well in my testing. My receiver has 75 volume steps, so sometimes I get weird rounding issues when setting a 0-100 value. It just causes the volume to flip between two numbers before finally giving up. 

I apologize if the topics don't follow your standard, I can always change them. I'm not super familiar with the MQTT best practices, and didn't want to rewrite all of your existing topics and actions to fit a new schema. 