### PR TITLE
Added configurable devicename for mqtt.

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -13,6 +13,7 @@ import os
 config = {
     'mqtt': {
         'broker': 'localhost',
+        'devicename': 'cec-ir-mqtt',
         'port': 1883,
         'prefix': 'media',
         'user': os.environ.get('MQTT_USER'),
@@ -347,7 +348,7 @@ try:
 
     ### Setup MQTT ###
     print("Initialising MQTT...")
-    mqtt_client = mqtt.Client("cec-ir-mqtt")
+    mqtt_client = mqtt.Client(config['mqtt']['devicename'])
     mqtt_client.on_connect = mqtt_on_connect
     mqtt_client.on_message = mqtt_on_message
     if config['mqtt']['user']:

--- a/config.default.ini
+++ b/config.default.ini
@@ -5,6 +5,9 @@
 ; Hostname of mqtt broker (required)
 ;broker=localhost
 
+; Name of your device (default=cec-ir-mqtt)
+;devicename=cec-ir-mqtt 
+
 ; Port to connect to (default=1883)
 ;port=1883
 


### PR DESCRIPTION
As described in issue https://github.com/michaelarnauts/cec-mqtt-bridge/issues/19

Added possibility to configure mqtt devicename. 
Will not affect name of lirc or cec, only mqtt.
