### PR TITLE
Allow enabling of tls usage for mqtt connection

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -18,7 +18,7 @@ config = {
         'prefix': 'media',
         'user': os.environ.get('MQTT_USER'),
         'password': os.environ.get('MQTT_PASSWORD'),
-        'tls': False,
+        'tls': 0,
     },
     'cec': {
         'enabled': 0,
@@ -354,7 +354,7 @@ try:
     mqtt_client.on_message = mqtt_on_message
     if config['mqtt']['user']:
         mqtt_client.username_pw_set(config['mqtt']['user'], password=config['mqtt']['password']);
-    if config['mqtt']['tls']:
+    if int(config['mqtt']['tls']) == 1:
         mqtt_client.tls_set();
     mqtt_client.will_set(config['mqtt']['prefix'] + '/bridge/status', 'offline', qos=1, retain=True)
     mqtt_client.connect(config['mqtt']['broker'], int(config['mqtt']['port']), 60)

--- a/bridge.py
+++ b/bridge.py
@@ -18,6 +18,7 @@ config = {
         'prefix': 'media',
         'user': os.environ.get('MQTT_USER'),
         'password': os.environ.get('MQTT_PASSWORD'),
+        'tls': False,
     },
     'cec': {
         'enabled': 0,
@@ -353,6 +354,8 @@ try:
     mqtt_client.on_message = mqtt_on_message
     if config['mqtt']['user']:
         mqtt_client.username_pw_set(config['mqtt']['user'], password=config['mqtt']['password']);
+    if config['mqtt']['tls']:
+        mqtt_client.tls_set();
     mqtt_client.will_set(config['mqtt']['prefix'] + '/bridge/status', 'offline', qos=1, retain=True)
     mqtt_client.connect(config['mqtt']['broker'], int(config['mqtt']['port']), 60)
     mqtt_client.loop_start()

--- a/config.default.ini
+++ b/config.default.ini
@@ -12,7 +12,7 @@
 ;port=1883
 
 ; Use tls
-;tls=False
+;tls=0
 
 ; Username and password
 ;user=

--- a/config.default.ini
+++ b/config.default.ini
@@ -11,6 +11,9 @@
 ; Port to connect to (default=1883)
 ;port=1883
 
+; Use tls
+;tls=False
+
 ; Username and password
 ;user=
 ;password=


### PR DESCRIPTION
This adds a `tls` config to the mqtt-settings, that when set to `True` will make the mqtt-client connect using tls.
This is especially useful if the mqtt-broker is available over the internet, because in that case it is important for the connection to be secure