### PR TITLE
 Add config for ir sleep time

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -28,7 +28,7 @@ config = {
     },
     'ir': {
         'enabled': 0,
-        'sleep': 0.2
+        'sleep': 0.2,
     }
 }
 

--- a/bridge.py
+++ b/bridge.py
@@ -18,7 +18,7 @@ config = {
         'prefix': 'media',
         'user': os.environ.get('MQTT_USER'),
         'password': os.environ.get('MQTT_PASSWORD'),
-        'tls': False,
+        'tls': 0,
     },
     'cec': {
         'enabled': 0,
@@ -354,7 +354,7 @@ try:
     mqtt_client.on_message = mqtt_on_message
     if config['mqtt']['user']:
         mqtt_client.username_pw_set(config['mqtt']['user'], password=config['mqtt']['password']);
-    if config['mqtt']['tls']:
+    if int(config['mqtt']['tls']) == 1:
         mqtt_client.tls_set();
     mqtt_client.will_set(config['mqtt']['prefix'] + '/bridge/status', 'offline', qos=1, retain=True)
     mqtt_client.connect(config['mqtt']['broker'], int(config['mqtt']['port']), 60)

--- a/bridge.py
+++ b/bridge.py
@@ -28,6 +28,7 @@ config = {
     },
     'ir': {
         'enabled': 0,
+        'sleep': 0.2
     }
 }
 
@@ -247,6 +248,7 @@ def cec_send(cmd, id=None):
 
 def ir_listen_thread():
     try:
+        sleep_time = float(config['ir']['sleep'])
         while True:
             try:
                 code = lirc.nextcode()
@@ -261,7 +263,7 @@ def ir_listen_thread():
                     code = code[1].strip()
                     mqtt_send(config['mqtt']['prefix'] + '/ir/' + remote + '/rx', code)
             else:
-                time.sleep(0.2)
+                time.sleep(sleep_time)
     except:
         return
 

--- a/bridge.py
+++ b/bridge.py
@@ -18,6 +18,7 @@ config = {
         'prefix': 'media',
         'user': os.environ.get('MQTT_USER'),
         'password': os.environ.get('MQTT_PASSWORD'),
+        'tls': False,
     },
     'cec': {
         'enabled': 0,
@@ -353,6 +354,8 @@ try:
     mqtt_client.on_message = mqtt_on_message
     if config['mqtt']['user']:
         mqtt_client.username_pw_set(config['mqtt']['user'], password=config['mqtt']['password']);
+    if config['mqtt']['tls']:
+        mqtt_client.tls_set();
     mqtt_client.will_set(config['mqtt']['prefix'] + '/bridge/status', 'offline', qos=1, retain=True)
     mqtt_client.connect(config['mqtt']['broker'], int(config['mqtt']['port']), 60)
     mqtt_client.loop_start()

--- a/config.default.ini
+++ b/config.default.ini
@@ -43,3 +43,6 @@
 [ir]
 ; Enable LIRC
 ;enabled=1
+
+; Set sleep time between ir code fetches
+;sleep=0.2

--- a/config.default.ini
+++ b/config.default.ini
@@ -12,7 +12,7 @@
 ;port=1883
 
 ; Use tls
-;tls=False
+;tls=0
 
 ; Username and password
 ;user=

--- a/config.default.ini
+++ b/config.default.ini
@@ -11,6 +11,9 @@
 ; Port to connect to (default=1883)
 ;port=1883
 
+; Use tls
+;tls=False
+
 ; Username and password
 ;user=
 ;password=


### PR DESCRIPTION
This moves the sleep-time of ir-command-checks to a config variable. With this change you can reduce the ir sleep-time (or increase it, though i wouldn't know why anyone would wand that).

reducing the sleep time in turn reduces the delay between receiving an ir command and the associated mqtt-message, which can make actions (like pressing a button on a remote and the resulting action based on the mqtt message) feel snappier.

In my example i have one Raspberry PI running this bridge and another one that is connected to the remote control of my sound system and running an mqtt client. With this change, using the volume-buttons on my ir-remote feels snappier (i set it to `0.01` instead of the default `0.2`)