### PR TITLE
Wait for mqtt on startup

### DIFF
--- a/lib/hdmicec.py
+++ b/lib/hdmicec.py
@@ -225,7 +225,7 @@ class HdmiCec:
         if self.setting_volume:
             return
 
-        LOGGER.info('Refreshing HDMI-CEC...')
+        LOGGER.debug('Refreshing HDMI-CEC...')
 
         for device in self.devices:
             # Ask device to send us an power status update


### PR DESCRIPTION
Launching cec-mqtt-bridge on boot has problems if mqtt hasn't already started. This change puts the bridge into a loop on startup until mqtt is available. The change also ignores incoming mqtt messages unless the cec_class has been configured.

Also reduce the log level of cec refresh.

Note that running cec-mqtt-bridge as a service means mqtt can be configured as a prerequisite service which I do but this wait for mqtt on startup change adds that little bit extra protection. For reference here is my bridge.service file:

`Unit]
Description=CEC MQTT bridge
After=network-online.target mosquitto.service

[Service]
ExecStart=/opt/cec-mqtt-bridge/bridge.sh
Restart=always
User=xxxxxxx
Group=xxxxxxx
SyslogIdentifier=cec-mqtt-bridge

[Install]
WantedBy=multi-user.target`